### PR TITLE
Add PNG development output

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -6,10 +6,14 @@ quiet = no
 debug = yes
 
 ## Display specific
+display_class = display
 vcom = -2.08
  # None / CW / CCW / flip
 rotate = None
 spi_hz = 24000000
+# Display width / height
+#width = 800
+#height = 600
 
 ## Layout
 rows = 12

--- a/display.py
+++ b/display.py
@@ -91,7 +91,3 @@ class Display:
             self.display.draw_partial(LUT)
         else:
             self.display.draw_full(LUT)
-        
-        
-
-

--- a/display_png.py
+++ b/display_png.py
@@ -1,0 +1,47 @@
+import logging
+
+from PIL import Image
+
+logger = logging.getLogger(__name__)
+
+
+class Display:
+    def __init__(self, cfg):
+        self.logger = logging.getLogger(__name__)
+        self.filename = 'display.png'
+        self.height = cfg.getint('main', 'height', fallback=600)
+        self.width = cfg.getint('main', 'width', fallback=800)
+        self.frame_buf = Image.new('L', (self.width, self.height), 0xFF)
+
+    def clear(self):
+        self.clearBuf()
+        self.draw_full()
+
+    def clearBuf(self):
+        self.frame_buf.paste(0xFF, box=(0, 0, self.width, self.height))
+
+    def getBuf(self):
+        return self.frame_buf.copy()
+
+    def updateBuf(self, buf):
+        self.frame_buf.paste(buf)
+
+    def refresh(self, partial=False, greyscale=True, flash=True):
+        if not greyscale:
+            if flash:
+                # Go to white image first
+                tmpBuf = self.getBuf()
+                self.clearBuf()
+                self.draw_full()
+                self.updateBuf(tmpBuf)
+
+        if partial:
+            self.draw_partial()
+        else:
+            self.draw_full()
+
+    def draw_partial(self):
+        self.frame_buf.save(self.filename)
+
+    def draw_full(self):
+        self.frame_buf.save(self.filename)

--- a/helpers/fontawesome.py
+++ b/helpers/fontawesome.py
@@ -78,4 +78,3 @@ class FontAwesome:
                 pos[0] + icon.width, pos[1] + icon.height
             )
             canvas.paste(icon, box)
-

--- a/helpers/imagefun.py
+++ b/helpers/imagefun.py
@@ -136,9 +136,3 @@ class ImageFun:
                 d.line([xy1, xy2], fill=self.borderCol, width=self.borderWidth)
                 self.circle(d, xy1, self.borderWidth // 2, self.borderCol)
                 self.circle(d, xy2, self.borderWidth // 2, self.borderCol)
-                
-
-
-
-
-

--- a/helpers/plot.py
+++ b/helpers/plot.py
@@ -264,5 +264,3 @@ class Plot:
             pos[0] + width, pos[1] + height
         )
         canvas.paste(img, box)
-
-

--- a/helpers/testfun.py
+++ b/helpers/testfun.py
@@ -119,6 +119,3 @@ def runWidget(config, display, canvas, name):
         widget.cleanup()
     except:
         pass
-
-
-

--- a/helpers/textfun.py
+++ b/helpers/textfun.py
@@ -122,4 +122,3 @@ class Text:
         hh = max(hh, fontsize)
 
         return (width, hh - pos[1])
-

--- a/run.py
+++ b/run.py
@@ -8,10 +8,10 @@ import sys
 import signal
 import configparser
 import logging
+import importlib
 from threading import Thread
 from time import sleep, perf_counter
 from PIL import Image, ImageOps, ImageDraw
-from display import Display
 from scheduler import Scheduler, Metronome
 from helpers.testfun import runWidget
 
@@ -42,7 +42,12 @@ def init():
         Open connection to display, create canvas
     '''
     global display, canvas
-    display = Display(config)
+    display_class = config.get('main', 'display_class')
+    if not display_class:
+        logger.error("missing 'display_class' in config file")
+        sys.exit(1)
+    mod = importlib.import_module(display_class)
+    display = mod.Display(config)
     display.clear()
 
     logger.info('Connected to display.')

--- a/run.py
+++ b/run.py
@@ -100,5 +100,3 @@ if __name__ == '__main__':
     # Wait indefinitely for signals
     while True:
         signal.pause()
-
-

--- a/scheduler.py
+++ b/scheduler.py
@@ -367,8 +367,3 @@ class Scheduler:
 
             self.display.updateBuf(self.canvas)
             self.display.refresh(greyscale = False, partial = True, flash = False)
-
-            
-
-
-

--- a/util/get-google-calendars.py
+++ b/util/get-google-calendars.py
@@ -92,4 +92,3 @@ def get_calendars():
 
 if __name__ == '__main__':
     get_calendars()
-

--- a/widgets/Calendar.py
+++ b/widgets/Calendar.py
@@ -210,6 +210,3 @@ class Calendar:
 
     def getCanvas(self):
         return self.canvas
-
-
-

--- a/widgets/Clock.py
+++ b/widgets/Clock.py
@@ -128,4 +128,3 @@ class Clock:
 
     def getCanvas(self):
         return self.canvas
-

--- a/widgets/Dummy.py
+++ b/widgets/Dummy.py
@@ -80,5 +80,3 @@ class Dummy:
         # Add code that runs before the display is shut down here (e.g. saving a state)
         self.logger.info('Cleaning up!')
         return
-
-

--- a/widgets/MQTT.py
+++ b/widgets/MQTT.py
@@ -141,5 +141,3 @@ class MQTT:
     def cleanup(self):
         self.mqttc.loop_stop()
         return
-
-

--- a/widgets/Rain.py
+++ b/widgets/Rain.py
@@ -155,4 +155,3 @@ class Rain:
 
     def getCanvas(self):
         return self.canvas
-

--- a/widgets/Weather.py
+++ b/widgets/Weather.py
@@ -1052,4 +1052,3 @@ class Weather:
 
         # Default
         return 'regular/question-circle'
-

--- a/widgets/_calendar_demo.py
+++ b/widgets/_calendar_demo.py
@@ -35,4 +35,3 @@ class Demo:
         '''
 
         return self.sample_list
-

--- a/widgets/_calendar_google.py
+++ b/widgets/_calendar_google.py
@@ -181,4 +181,3 @@ class Google:
         utc_time_ahead = time_ahead.astimezone(timezone.utc)
 
         return self._get_events(utc_time, utc_time_ahead)
-


### PR DESCRIPTION
This PR adds a new config option which if set to `display_class = display_png`  is useful for local development where a `display.png` is written on every draw. This is useful for local development without an e-ink monitor.